### PR TITLE
Updated routine "all" to choose from full list of possible dances

### DIFF
--- a/src/danceArea.ts
+++ b/src/danceArea.ts
@@ -60,7 +60,7 @@ export class DanceSystem {
   dance() {
     this.timer = this.length
     if (this.routine === 'all') {
-      const rand = Math.floor(Math.random() * (this.routine.length - 0) + 0)
+      const rand = Math.floor(Math.random() * (this.routines.length - 0) + 0)
       void triggerEmote({ predefined: this.routines[rand] })
     } else {
       void triggerEmote({ predefined: this.routine })


### PR DESCRIPTION
Line #63: use of `this.routine.length` for the random number input results in only dances 0-2 being used when using routine "all". This should instead use the length of the `this.routines` array to use all possible dances.